### PR TITLE
Adjust scanelf to properly detect runDeps

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -109,11 +109,10 @@ RUN set -ex; \
 	; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .bash-rundeps $runDeps; \
 	apk del .build-deps; \

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -109,11 +109,10 @@ RUN set -ex; \
 	; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .bash-rundeps $runDeps; \
 	apk del .build-deps; \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -109,11 +109,10 @@ RUN set -ex; \
 	; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .bash-rundeps $runDeps; \
 	apk del .build-deps; \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -112,11 +112,10 @@ RUN set -ex; \
 	; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .bash-rundeps $runDeps; \
 	apk del .build-deps; \

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -109,11 +109,10 @@ RUN set -ex; \
 	; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .bash-rundeps $runDeps; \
 	apk del .build-deps; \

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -109,11 +109,10 @@ RUN set -ex; \
 	; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .bash-rundeps $runDeps; \
 	apk del .build-deps; \

--- a/4.3/Dockerfile
+++ b/4.3/Dockerfile
@@ -110,11 +110,10 @@ RUN set -ex; \
 	; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .bash-rundeps $runDeps; \
 	apk del .build-deps; \

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -110,11 +110,10 @@ RUN set -ex; \
 	; \
 	\
 	runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
 	apk add --no-cache --virtual .bash-rundeps $runDeps; \
 	apk del .build-deps; \


### PR DESCRIPTION
Copying the improvement from https://github.com/docker-library/ruby/pull/161.  Should be no discernible change in packages installed, but does make the sub-shell a little easier to understand.