### PR TITLE
Add suite aliases ("alpine3.12")

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -88,11 +88,15 @@ for version; do
 	parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
 	arches="${parentRepoToArches[$parent]}"
 
+	alpine="${parent#*:}" # "3.14"
+	suiteAliases=( "${versionAliases[@]/%/-alpine$alpine}" )
+	suiteAliases=( "${suiteAliases[@]//latest-/}" )
+
 	commit="$(dirCommit "$version")"
 
 	echo
 	cat <<-EOE
-		Tags: $(join ', ' "${versionAliases[@]}")
+		Tags: $(join ', ' "${versionAliases[@]}" "${suiteAliases[@]}")
 		Architectures: $(join ', ' $arches)
 		GitCommit: $commit
 		Directory: $version


### PR DESCRIPTION
This is a pre-requisite to #24 so users that get broken by that have an easy escape hatch.

See also:

- https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirements
- https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2

<details>
<summary>Diff:</summary>

```diff
$ diff -u <(bashbrew cat bash) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2021-08-23 12:47:18.451110988 -0700
+++ /dev/fd/62	2021-08-23 12:47:18.451110988 -0700
@@ -1,57 +1,57 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: devel-20210813, devel
+Tags: devel-20210813, devel, devel-20210813-alpine3.12, devel-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9f556d714c5224e679c32962377bc784e880f56b
 Directory: devel
 
-Tags: 5.1.8, 5.1, 5, latest
+Tags: 5.1.8, 5.1, 5, latest, 5.1.8-alpine3.12, 5.1-alpine3.12, 5-alpine3.12, alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2d1a192e467f18b630166ea5efd99b1dc8ca1fb
 Directory: 5.1
 
-Tags: 5.0.18, 5.0
+Tags: 5.0.18, 5.0, 5.0.18-alpine3.12, 5.0-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2d1a192e467f18b630166ea5efd99b1dc8ca1fb
 Directory: 5.0
 
-Tags: 4.4.23, 4.4, 4
+Tags: 4.4.23, 4.4, 4, 4.4.23-alpine3.12, 4.4-alpine3.12, 4-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2d1a192e467f18b630166ea5efd99b1dc8ca1fb
 Directory: 4.4
 
-Tags: 4.3.48, 4.3
+Tags: 4.3.48, 4.3, 4.3.48-alpine3.12, 4.3-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2d1a192e467f18b630166ea5efd99b1dc8ca1fb
 Directory: 4.3
 
-Tags: 4.2.53, 4.2
+Tags: 4.2.53, 4.2, 4.2.53-alpine3.12, 4.2-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2d1a192e467f18b630166ea5efd99b1dc8ca1fb
 Directory: 4.2
 
-Tags: 4.1.17, 4.1
+Tags: 4.1.17, 4.1, 4.1.17-alpine3.12, 4.1-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2d1a192e467f18b630166ea5efd99b1dc8ca1fb
 Directory: 4.1
 
-Tags: 4.0.44, 4.0
+Tags: 4.0.44, 4.0, 4.0.44-alpine3.12, 4.0-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2d1a192e467f18b630166ea5efd99b1dc8ca1fb
 Directory: 4.0
 
-Tags: 3.2.57, 3.2, 3
+Tags: 3.2.57, 3.2, 3, 3.2.57-alpine3.12, 3.2-alpine3.12, 3-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2d1a192e467f18b630166ea5efd99b1dc8ca1fb
 Directory: 3.2
 
-Tags: 3.1.23, 3.1
+Tags: 3.1.23, 3.1, 3.1.23-alpine3.12, 3.1-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2d1a192e467f18b630166ea5efd99b1dc8ca1fb
 Directory: 3.1
 
-Tags: 3.0.22, 3.0
+Tags: 3.0.22, 3.0, 3.0.22-alpine3.12, 3.0-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2d1a192e467f18b630166ea5efd99b1dc8ca1fb
 Directory: 3.0
```

</details>