### PR TITLE
Support reproducible builds (except packages)

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -14,9 +14,13 @@ ENV _BASH_BASELINE_PATCH 16
 ENV _BASH_LATEST_PATCH 22
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -44,7 +48,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -71,18 +75,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -122,7 +133,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -13,9 +13,13 @@ ENV _BASH_BASELINE 3.1
 ENV _BASH_LATEST_PATCH 23
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -43,7 +47,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -70,18 +74,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -121,7 +132,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -14,9 +14,13 @@ ENV _BASH_BASELINE_PATCH 57
 ENV _BASH_LATEST_PATCH 57
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -44,7 +48,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -71,18 +75,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -122,7 +133,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -13,9 +13,13 @@ ENV _BASH_BASELINE 4.0
 ENV _BASH_LATEST_PATCH 44
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -43,7 +47,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -70,18 +74,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -124,7 +135,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -13,9 +13,13 @@ ENV _BASH_BASELINE 4.1
 ENV _BASH_LATEST_PATCH 17
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -43,7 +47,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -70,18 +74,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -119,7 +130,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -14,9 +14,13 @@ ENV _BASH_BASELINE_PATCH 53
 ENV _BASH_LATEST_PATCH 53
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -44,7 +48,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -71,18 +75,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -120,7 +131,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/4.3/Dockerfile
+++ b/4.3/Dockerfile
@@ -14,9 +14,13 @@ ENV _BASH_BASELINE_PATCH 30
 ENV _BASH_LATEST_PATCH 48
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -44,7 +48,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -71,18 +75,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -120,7 +131,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -14,9 +14,13 @@ ENV _BASH_BASELINE_PATCH 18
 ENV _BASH_LATEST_PATCH 23
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -44,7 +48,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -71,18 +75,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -120,7 +131,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -13,9 +13,13 @@ ENV _BASH_BASELINE 5.0
 ENV _BASH_LATEST_PATCH 18
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -43,7 +47,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -70,18 +74,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -115,7 +126,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/5.1/Dockerfile
+++ b/5.1/Dockerfile
@@ -14,9 +14,13 @@ ENV _BASH_BASELINE_PATCH 16
 ENV _BASH_LATEST_PATCH 16
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -44,7 +48,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -71,18 +75,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -116,7 +127,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/5.2/Dockerfile
+++ b/5.2/Dockerfile
@@ -14,9 +14,13 @@ ENV _BASH_BASELINE_PATCH 37
 ENV _BASH_LATEST_PATCH 37
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -44,7 +48,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -71,18 +75,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -116,7 +127,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/5.3-rc/Dockerfile
+++ b/5.3-rc/Dockerfile
@@ -11,9 +11,13 @@ ENV _BASH_VERSION 5.3-alpha
 ENV _BASH_BASELINE 5.3-alpha
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -41,7 +45,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -68,18 +72,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 	cd /usr/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
@@ -113,7 +124,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -19,9 +19,13 @@ ENV _BASH_LATEST_PATCH {{ .patch.version }}
 {{ ) end -}}
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -52,7 +56,7 @@ RUN set -eux; \
 		done; \
 	fi; \
 	\
-	apk add --no-cache --virtual .gpg-deps gnupg; \
+	apk add --no-cache --virtual .gpg-deps=0 gnupg; \
 	export GNUPGHOME="$(mktemp -d)"; \
 # gpg: key 64EA74AB: public key "Chet Ramey <chet@cwru.edu>" imported
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB; \
@@ -80,18 +84,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 {{ if env.version == "devel" then ( -}}
 	\
 # https://lists.gnu.org/archive/html/bug-bash/2023-05/msg00011.html
@@ -146,7 +157,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \

--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -12,9 +12,13 @@ ENV _BASH_COMMIT 5edfaa45e791bbb2bf6c9342e13e5e364ff87bad
 ENV _BASH_VERSION devel-20241012
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+# The global SOURCE_DATE_EPOCH is consumed by commands that are not associated with a source artifact.
+# This is not propagated from --build-arg: https://github.com/moby/buildkit/issues/4576#issuecomment-2159501282
+ENV SOURCE_DATE_EPOCH 0
+
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache --virtual .build-deps=0 \
 		bison \
 		coreutils \
 		dpkg-dev dpkg \
@@ -38,18 +42,25 @@ RUN set -eux; \
 	rm bash.tar.gz; \
 	\
 	if [ -d bash-patches ]; then \
-		apk add --no-cache --virtual .patch-deps patch; \
+		apk add --no-cache --virtual .patch-deps=0 patch; \
 		for p in bash-patches/*; do \
+# --force is set for reproducing timestamps
 			patch \
 				--directory=/usr/src/bash \
 				--input="$(readlink -f "$p")" \
 				--strip=0 \
+				--set-utc \
+				--force \
 			; \
 			rm "$p"; \
 		done; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	SOURCE_DATE_EPOCH="$(find /usr/src/bash -type f -exec stat -c '%Y' {} + | sort -nr | head -n1)"; \
+	export SOURCE_DATE_EPOCH; \
+# for logging validation/edification
+	date --date "@$SOURCE_DATE_EPOCH" --rfc-2822; \
 	\
 # https://lists.gnu.org/archive/html/bug-bash/2023-05/msg00011.html
 	{ echo '#include <unistd.h>'; echo; cat /usr/src/bash/lib/sh/strscpy.c; } > /usr/src/bash/lib/sh/strscpy.c.new; \
@@ -87,7 +98,7 @@ RUN set -eux; \
 			| sort -u \
 			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)"; \
-	apk add --no-network --virtual .bash-rundeps $runDeps; \
+	apk add --no-network --virtual .bash-rundeps=0 $runDeps; \
 	apk del --no-network .build-deps; \
 	\
 	[ "$(which bash)" = '/usr/local/bin/bash' ]; \


### PR DESCRIPTION
See:
- docker-library/official-images#16044

- `SOURCE_DATE_EPOCH` is added. The value is consumed by the build scripts to make the binary reproducible.

- For Alpine, virtual package versions are pinned to "0" to eliminate the timestamp-based version numbers that appear in `/etc/apk/world` and `/lib/apk/db/installed`

> [!NOTE]
> The following topics are NOT covered by this commit:
>
> - To reproduce file timestamps in layers, BuildKit has to be executed with
>   `--output type=<TYPE>,rewrite-timestamp=true`.
>   Needs BuildKit v0.13 or later.
>
> - To reproduce the base image by the hash, reproducers may:
>   - modify the `FROM` instruction in Dockerfile manually
>   - or, use the `CONVERT` action of source policies to replace the base image.
>     <https://github.com/moby/buildkit/blob/v0.13.2/docs/build-repro.md>
>
> - To reproduce packages, see the `RUN` instruction hook proposed in
>   moby/buildkit#4576
