### PR TITLE
Use cgit atom feed to find devel commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .jq-template.awk
+.yq

--- a/versions.sh
+++ b/versions.sh
@@ -40,21 +40,78 @@ for version in "${versions[@]}"; do
 	fi
 
 	if [ "$version" = 'devel' ]; then
-		git clone --quiet --branch devel --depth 10 https://git.savannah.gnu.org/git/bash.git "$tmp/devel"
-		snapshotDate="$(TZ=UTC date --date 'last monday 23:59:59' '+%Y-%m-%d %H:%M:%S %Z')" # https://github.com/docker-library/faq#can-i-use-a-bot-to-make-my-image-update-prs
-		commit="$(git -C "$tmp/devel" log --before="$snapshotDate" --format='format:%H' --max-count=1)"
-		if [ -z "$commit" ]; then
-			echo >&2 "error: cannot determine commit for $version (from https://git.savannah.gnu.org/cgit/bash.git)"
+		yq='./.yq'
+		# https://github.com/mikefarah/yq/releases
+		# TODO detect host architecture
+		yqUrl='https://github.com/mikefarah/yq/releases/download/v4.44.5/yq_linux_amd64'
+		yqSha256='638c4b251c49201fc94b598834b715f8f1c6e9b1854d2820772d2c79f0289002'
+		if command -v yq &> /dev/null; then
+			# TODO verify that the "yq" in PATH is https://github.com/mikefarah/yq, not the python-based version you'd get from "apt-get install yq" somehow?  maybe they're compatible enough for our needs that it doesn't matter?
+			yq='yq'
+		elif [ ! -x "$yq" ] || ! sha256sum <<<"$yqSha256 *$yq" --quiet --strict --check; then
+			wget -qO "$yq.new" "$yqUrl"
+			sha256sum <<<"$yqSha256 *$yq.new" --quiet --strict --check
+			chmod +x "$yq.new"
+			"$yq.new" --version
+			mv "$yq.new" "$yq"
+		fi
+
+		# https://github.com/docker-library/faq#can-i-use-a-bot-to-make-my-image-update-prs
+		snapshotDate="$(date --utc --date 'last monday 23:59:59' '+%s')"
+		commit='devel' # this is also our iteration variable, so if we don't find a suitable commit each time through this loop, we'll use the last commit of the previous list to get a list of new (older) commits until we find one suitably old enough
+		fullVersion=
+		while [ -z "$fullVersion" ]; do
+			commits="$(
+				wget -qO- "https://git.savannah.gnu.org/cgit/bash.git/atom/?h=$commit" \
+					| "$yq" --input-format xml --output-format json \
+					| jq -r '
+						.feed.entry[]
+						| select(
+							(.id | startswith("urn:sha1:"))
+							and .updated // .published
+							and .title
+						)
+						| [
+							@sh "commit=\(.id | ltrimstr("urn:sha1:"))",
+							@sh "date=\([ .updated, .published ] | sort | reverse[0])",
+							@sh "desc=\(.title)",
+							empty
+						]
+						| join("\n")
+						| @sh
+					'
+			)"
+			eval "commits=( $commits )"
+			if [ "${#commits[@]}" -eq 0 ]; then
+				echo >&2 "error: got no commits when listing history from $commit"
+				exit 1
+			fi
+			for commitShell in "${commits[@]}"; do
+				unset commit date desc
+				eval "$commitShell"
+				[ -n "$commit" ]
+				[ -n "$date" ]
+				[ -n "$desc" ]
+				date="$(date --utc --date "$date" '+%s')"
+				if [ "$date" -le "$snapshotDate" ]; then
+					fullVersion="$commit"
+					break 2
+				fi
+			done
+		done
+		if [ -z "$fullVersion" ]; then
+			snapshotDateStr="$(date --utc --date "@$snapshotDate" '+%Y-%m-%d %H:%M:%S %Z')"
+			echo >&2 "error: cannot find full version for $version (maybe too many commits since $snapshotDateStr? cgit changed the atom feed format? yq changed how it parses XML?)"
 			exit 1
 		fi
-		desc="$(git -C "$tmp/devel" log --max-count=1 --format='format:%s' "$commit")"
+		[ "$commit" = "$fullVersion" ]
+		[ -n "$date" ]
 		[ -n "$desc" ]
+
 		if timestamp="$(sed -rne '/.*[[:space:]]+bash-([0-9]+)[[:space:]]+.*/s//\1/p' <<<"$desc")" && [ -n "$timestamp" ]; then
-			: # "commit bash-20210305 snapshot"
+			: # "commit bash-20210305 snapshot" (https://git.savannah.gnu.org/cgit/bash.git/commit/?h=devel&id=11bf534f3628cc0a592866ee4f689beca473f548)
 		else
-			timestamp="$(git -C "$tmp/devel" log --max-count=1 --format='format:%aI' "$commit")" # ideally we'd use "%as" and just axe "-" but that requires newer Git than Debian 10 has /o\
-			timestamp="${timestamp%%T*}"
-			timestamp="${timestamp//-/}"
+			timestamp="$(date --utc --date "@$date" '+%Y%m%d')"
 		fi
 
 		echo "$version: $commit ($timestamp -- $desc)"


### PR DESCRIPTION
This avoids doing an expensive temporary checkout and lets us get to the answer much faster.

The approach here is very inspired by/copied from https://github.com/docker-library/golang/pull/531