### PR TITLE
Update all versions to Alpine 3.21

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 # https://ftp.gnu.org/gnu/bash/?C=M;O=D
 ENV _BASH_VERSION 3.0.22
@@ -13,6 +13,8 @@ ENV _BASH_BASELINE_PATCH 16
 # https://ftp.gnu.org/gnu/bash/bash-3.0-patches/?C=M;O=D
 ENV _BASH_LATEST_PATCH 22
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
+
+COPY alpine3.21.patch /usr/local/src/tianon-bash-patches/
 
 RUN set -eux; \
 	\
@@ -83,6 +85,14 @@ RUN set -eux; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	\
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 	\
 	cd /usr/local/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/3.0/alpine3.21.patch
+++ b/3.0/alpine3.21.patch
@@ -1,0 +1,226 @@
+Description: minor fixes for Alpine 3.21+
+Author: Tianon (& Chet, for fixes borrowed/backported)
+
+diff --git a/builtins/evalfile.c b/builtins/evalfile.c
+index c17e547b..81be017b 100644
+--- a/builtins/evalfile.c
++++ b/builtins/evalfile.c
+@@ -39,6 +39,7 @@
+ #include "../flags.h"
+ #include "../input.h"
+ #include "../execute_cmd.h"
++#include "../trap.h"
+ 
+ #if defined (HISTORY)
+ #  include "../bashhist.h"
+
+diff --git a/externs.h b/externs.h
+index a015d782..c745c2aa 100644
+--- a/externs.h
++++ b/externs.h
+@@ -362,6 +362,9 @@ extern int sh_mktmpfd __P((char *, int, char **));
+ #undef xstrchr
+ extern char *xstrchr __P((const char *, int));
+ 
++/* declarations for functions defined in lib/sh/zcatfd.c */
++extern int zcatfd __P((int, int, char *));
++
+ /* declarations for functions defined in lib/sh/zread.c */
+ extern ssize_t zread __P((int, char *, size_t));
+ extern ssize_t zreadintr __P((int, char *, size_t));
+
+diff --git a/general.c b/general.c
+index 0b9c8fb6..3384e84b 100644
+--- a/general.c
++++ b/general.c
+@@ -39,6 +39,8 @@
+ #include "bashintl.h"
+ 
+ #include "shell.h"
++#include "test.h"
++
+ #include <tilde/tilde.h>
+ 
+ #if !defined (errno)
+
+diff --git a/lib/glob/strmatch.c b/lib/glob/strmatch.c
+index 4d9c68d0..cea9bd86 100644
+--- a/lib/glob/strmatch.c
++++ b/lib/glob/strmatch.c
+@@ -25,7 +25,7 @@
+ #include "strmatch.h"
+ 
+ extern int xstrmatch __P((char *, char *, int));
+-#if defined (HAVE_MULTIBYTE)
++#if defined (HANDLE_MULTIBYTE)
+ extern int internal_wstrmatch __P((wchar_t *, wchar_t *, int));
+ #endif
+ 
+
+diff --git a/lib/intl/Makefile.in b/lib/intl/Makefile.in
+index 70bafc9c..8520ed2e 100644
+--- a/lib/intl/Makefile.in
++++ b/lib/intl/Makefile.in
+@@ -51,12 +51,14 @@ RANLIB = @RANLIB@
+ YACC = @INTLBISON@ -y -d
+ YFLAGS = --name-prefix=__gettext
+ 
++LOCAL_DEFS = @LOCAL_DEFS@
++
+ DEFS = -DLOCALEDIR=\"$(localedir)\" -DLOCALE_ALIAS_PATH=\"$(aliaspath)\" \
+ -DLIBDIR=\"$(prefix)/libdata\" -DIN_LIBINTL \
+ -DENABLE_RELOCATABLE=1 -DIN_LIBRARY -DINSTALLDIR=\"$(libdir)\" -DNO_XMALLOC \
+ -Dset_relocation_prefix=libintl_set_relocation_prefix \
+ -Drelocate=libintl_relocate \
+--DDEPENDS_ON_LIBICONV=1 @DEFS@
++-DDEPENDS_ON_LIBICONV=1 @DEFS@ @LOCAL_DEFS@
+ CPPFLAGS = @CPPFLAGS@
+ CFLAGS = @CFLAGS@
+ LDFLAGS = @LDFLAGS@
+
+diff --git a/lib/intl/dcigettext.c b/lib/intl/dcigettext.c
+index f6edb95c..c7e696a8 100644
+--- a/lib/intl/dcigettext.c
++++ b/lib/intl/dcigettext.c
+@@ -134,6 +134,10 @@ extern int errno;
+ 
+ /* @@ end of prolog @@ */
+ 
++#if defined (SHELL) && !defined (HAVE_GETCWD)
++#  define HAVE_GETCWD
++#endif
++
+ #ifdef _LIBC
+ /* Rename the non ANSI C functions.  This is required by the standard
+    because some ANSI C functions will require linking with this object
+
+diff --git a/make_cmd.c b/make_cmd.c
+index 479d9c3e..df200105 100644
+--- a/make_cmd.c
++++ b/make_cmd.c
+@@ -355,6 +359,7 @@ COMMAND *
+ make_case_command (word, clauses, lineno)
+      WORD_DESC *word;
+      PATTERN_LIST *clauses;
++     int lineno;
+ {
+   CASE_COM *temp;
+ 
+diff --git a/nojobs.c b/nojobs.c
+index a3d51f67..7303f07f 100644
+--- a/nojobs.c
++++ b/nojobs.c
+@@ -45,6 +45,7 @@
+ 
+ #include "shell.h"
+ #include "jobs.h"
++#include "trap.h"
+ 
+ #include "builtins/builtext.h"	/* for wait_builtin */
+ 
+@@ -398,6 +399,7 @@ reap_dead_jobs ()
+ }
+ 
+ /* Initialize the job control mechanism, and set up the tty stuff. */
++int
+ initialize_job_control (force)
+      int force;
+ {
+@@ -838,6 +840,7 @@ static TTYSTRUCT shell_tty_info;
+ static int got_tty_state;
+ 
+ /* Fill the contents of shell_tty_info with the current tty info. */
++int
+ get_tty_state ()
+ {
+   int tty;
+@@ -869,10 +872,12 @@ set_tty_state ()
+ }
+ 
+ /* Give the terminal to PGRP.  */
++int
+ give_terminal_to (pgrp, force)
+      pid_t pgrp;
+      int force;
+ {
++  return 0;
+ }
+ 
+ /* Stop a pipeline. */
+
+diff --git a/parse.y b/parse.y
+index 5211fbcb..f0cdfbf4 100644
+--- a/parse.y
++++ b/parse.y
+@@ -69,6 +69,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #  include "jobs.h"
++#else
++extern int cleanup_dead_jobs __P((void));
++extern int count_all_jobs __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #if defined (ALIAS)
+
+diff --git a/shell.c b/shell.c
+index 2fd8179b..45b77f9e 100644
+--- a/shell.c
++++ b/shell.c
+@@ -57,6 +59,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #include "jobs.h"
++#else
++extern int initialize_job_control __P((int));
++extern int get_tty_state __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #include "input.h"
+
+diff --git a/sig.c b/sig.c
+index 8bc45c17..d31ca87b 100644
+--- a/sig.c
++++ b/sig.c
+@@ -60,6 +60,12 @@ extern int executing_list;
+ extern int comsub_ignore_return;
+ extern int parse_and_execute_level, shell_initialized;
+ 
++extern void initialize_siglist ();
++
++#if !defined (JOB_CONTROL)
++extern void initialize_job_signals __P((void));
++#endif
++
+ /* Non-zero after SIGINT. */
+ volatile int interrupt_state = 0;
+ 
+
+diff --git a/siglist.h b/siglist.h
+index 4cb65308..bc0ea441 100644
+--- a/siglist.h
++++ b/siglist.h
+@@ -18,6 +18,8 @@
+    along with Bash.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <string.h>
++
+ #if !defined (_SIGLIST_H_)
+ #define _SIGLIST_H_
+ 
+
+diff --git a/support/bashversion.c b/support/bashversion.c
+index abf1aa8d..59c2321e 100644
+--- a/support/bashversion.c
++++ b/support/bashversion.c
+@@ -47,6 +47,9 @@ extern char *optarg;
+ extern char *dist_version;
+ extern int patch_level;
+ 
++extern char *shell_version_string __P((void));
++extern void show_shell_version __P((int));
++
+ char *shell_name = "bash";
+ char *progname;
+ 

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 # https://ftp.gnu.org/gnu/bash/?C=M;O=D
 ENV _BASH_VERSION 3.1.23
@@ -12,6 +12,8 @@ ENV _BASH_BASELINE 3.1
 # https://ftp.gnu.org/gnu/bash/bash-3.1-patches/?C=M;O=D
 ENV _BASH_LATEST_PATCH 23
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
+
+COPY alpine3.21.patch /usr/local/src/tianon-bash-patches/
 
 RUN set -eux; \
 	\
@@ -82,6 +84,14 @@ RUN set -eux; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	\
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 	\
 	cd /usr/local/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/3.1/alpine3.21.patch
+++ b/3.1/alpine3.21.patch
@@ -1,0 +1,202 @@
+Description: minor fixes for Alpine 3.21+
+Author: Tianon (& Chet, for fixes borrowed/backported)
+
+diff --git a/builtins/echo.def b/builtins/echo.def
+index 6792659a..923c43a2 100644
+--- a/builtins/echo.def
++++ b/builtins/echo.def
+@@ -31,6 +31,8 @@ $PRODUCES echo.c
+ #include <stdio.h>
+ #include "../shell.h"
+ 
++#include "common.h"
++
+ $BUILTIN echo
+ $FUNCTION echo_builtin
+ $DEPENDS_ON V9_ECHO
+
+diff --git a/builtins/printf.def b/builtins/printf.def
+index b4a528fe..c8c0c633 100644
+--- a/builtins/printf.def
++++ b/builtins/printf.def
+@@ -588,7 +588,7 @@ printstr (fmt, string, len, fieldwidth, precision)
+ #else
+   if (string == 0 || len == 0)
+ #endif
+-    return;
++    return 0;
+ 
+ #if 0
+  s = fmt;
+
+diff --git a/lib/glob/strmatch.c b/lib/glob/strmatch.c
+index 4d9c68d0..cea9bd86 100644
+--- a/lib/glob/strmatch.c
++++ b/lib/glob/strmatch.c
+@@ -25,7 +25,7 @@
+ #include "strmatch.h"
+ 
+ extern int xstrmatch __P((char *, char *, int));
+-#if defined (HAVE_MULTIBYTE)
++#if defined (HANDLE_MULTIBYTE)
+ extern int internal_wstrmatch __P((wchar_t *, wchar_t *, int));
+ #endif
+ 
+
+diff --git a/lib/readline/callback.c b/lib/readline/callback.c
+index 9120969c..ada04d85 100644
+--- a/lib/readline/callback.c
++++ b/lib/readline/callback.c
+@@ -43,6 +43,7 @@
+ #include "rldefs.h"
+ #include "readline.h"
+ #include "rlprivate.h"
++#include "xmalloc.h"
+ 
+ /* Private data for callback registration functions.  See comments in
+    rl_callback_read_char for more details. */
+
+diff --git a/lib/sh/winsize.c b/lib/sh/winsize.c
+index 8b39c99e..f4696de0 100644
+--- a/lib/sh/winsize.c
++++ b/lib/sh/winsize.c
+@@ -55,6 +55,7 @@ extern int shell_tty;
+ #if defined (READLINE)
+ extern void rl_set_screen_size __P((int, int));
+ #endif
++extern void sh_set_lines_and_columns __P((int, int));
+ 
+ void
+ get_new_window_size (from_sig, rp, cp)
+
+diff --git a/nojobs.c b/nojobs.c
+index a3d51f67..7303f07f 100644
+--- a/nojobs.c
++++ b/nojobs.c
+@@ -45,6 +45,7 @@
+ 
+ #include "shell.h"
+ #include "jobs.h"
++#include "trap.h"
+ 
+ #include "builtins/builtext.h"	/* for wait_builtin */
+ 
+@@ -398,6 +399,7 @@ reap_dead_jobs ()
+ }
+ 
+ /* Initialize the job control mechanism, and set up the tty stuff. */
++int
+ initialize_job_control (force)
+      int force;
+ {
+@@ -838,6 +840,7 @@ static TTYSTRUCT shell_tty_info;
+ static int got_tty_state;
+ 
+ /* Fill the contents of shell_tty_info with the current tty info. */
++int
+ get_tty_state ()
+ {
+   int tty;
+@@ -869,10 +872,12 @@ set_tty_state ()
+ }
+ 
+ /* Give the terminal to PGRP.  */
++int
+ give_terminal_to (pgrp, force)
+      pid_t pgrp;
+      int force;
+ {
++  return 0;
+ }
+ 
+ /* Stop a pipeline. */
+
+diff --git a/parse.y b/parse.y
+index 5211fbcb..f0cdfbf4 100644
+--- a/parse.y
++++ b/parse.y
+@@ -69,6 +69,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #  include "jobs.h"
++#else
++extern int cleanup_dead_jobs __P((void));
++extern int count_all_jobs __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #if defined (ALIAS)
+
+diff --git a/shell.c b/shell.c
+index 2fd8179b..45b77f9e 100644
+--- a/shell.c
++++ b/shell.c
+@@ -57,6 +59,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #include "jobs.h"
++#else
++extern int initialize_job_control __P((int));
++extern int get_tty_state __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #include "input.h"
+
+diff --git a/sig.c b/sig.c
+index 8bc45c17..d31ca87b 100644
+--- a/sig.c
++++ b/sig.c
+@@ -60,6 +60,12 @@ extern int executing_list;
+ extern int comsub_ignore_return;
+ extern int parse_and_execute_level, shell_initialized;
+ 
++extern void initialize_siglist ();
++
++#if !defined (JOB_CONTROL)
++extern void initialize_job_signals __P((void));
++#endif
++
+ /* Non-zero after SIGINT. */
+ volatile int interrupt_state = 0;
+ 
+
+diff --git a/siglist.h b/siglist.h
+index 4cb65308..bc0ea441 100644
+--- a/siglist.h
++++ b/siglist.h
+@@ -18,6 +18,8 @@
+    along with Bash.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <string.h>
++
+ #if !defined (_SIGLIST_H_)
+ #define _SIGLIST_H_
+ 
+
+diff --git a/subst.c b/subst.c
+index 089457fb..2e24ac4e 100644
+--- a/subst.c
++++ b/subst.c
+@@ -2625,6 +2625,7 @@ expand_assignment_string_to_string (string, quoted)
+ char *
+ expand_arith_string (string, quoted)
+      char *string;
++     int quoted;
+ {
+   return (expand_string_if_necessary (string, quoted, expand_string));
+ }
+
+diff --git a/support/bashversion.c b/support/bashversion.c
+index abf1aa8d..59c2321e 100644
+--- a/support/bashversion.c
++++ b/support/bashversion.c
+@@ -47,6 +47,9 @@ extern char *optarg;
+ extern char *dist_version;
+ extern int patch_level;
+ 
++extern char *shell_version_string __P((void));
++extern void show_shell_version __P((int));
++
+ char *shell_name = "bash";
+ char *progname;
+ 

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 # https://ftp.gnu.org/gnu/bash/?C=M;O=D
 ENV _BASH_VERSION 3.2.57
@@ -13,6 +13,8 @@ ENV _BASH_BASELINE_PATCH 57
 # https://ftp.gnu.org/gnu/bash/bash-3.2-patches/?C=M;O=D
 ENV _BASH_LATEST_PATCH 57
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
+
+COPY alpine3.21.patch /usr/local/src/tianon-bash-patches/
 
 RUN set -eux; \
 	\
@@ -83,6 +85,14 @@ RUN set -eux; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	\
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 	\
 	cd /usr/local/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/3.2/alpine3.21.patch
+++ b/3.2/alpine3.21.patch
@@ -1,0 +1,161 @@
+Description: minor fixes for Alpine 3.21+
+Author: Tianon (& Chet, for fixes borrowed/backported)
+
+diff --git a/lib/glob/glob.c b/lib/glob/glob.c
+index 08a7da85..915bac3f 100644
+--- a/lib/glob/glob.c
++++ b/lib/glob/glob.c
+@@ -45,6 +45,7 @@
+ 
+ #include "stdc.h"
+ #include "memalloc.h"
++#include "sig.h" // needed by "quit.h"
+ #include "quit.h"
+ 
+ #include "glob.h"
+
+diff --git a/lib/glob/strmatch.c b/lib/glob/strmatch.c
+index 4d9c68d0..cea9bd86 100644
+--- a/lib/glob/strmatch.c
++++ b/lib/glob/strmatch.c
+@@ -25,7 +25,7 @@
+ #include "strmatch.h"
+ 
+ extern int xstrmatch __P((char *, char *, int));
+-#if defined (HAVE_MULTIBYTE)
++#if defined (HANDLE_MULTIBYTE)
+ extern int internal_wstrmatch __P((wchar_t *, wchar_t *, int));
+ #endif
+ 
+
+diff --git a/nojobs.c b/nojobs.c
+index a3d51f67..7303f07f 100644
+--- a/nojobs.c
++++ b/nojobs.c
+@@ -45,6 +45,7 @@
+ 
+ #include "shell.h"
+ #include "jobs.h"
++#include "trap.h"
+ 
+ #include "builtins/builtext.h"	/* for wait_builtin */
+ 
+@@ -398,6 +399,7 @@ reap_dead_jobs ()
+ }
+ 
+ /* Initialize the job control mechanism, and set up the tty stuff. */
++int
+ initialize_job_control (force)
+      int force;
+ {
+@@ -838,6 +840,7 @@ static TTYSTRUCT shell_tty_info;
+ static int got_tty_state;
+ 
+ /* Fill the contents of shell_tty_info with the current tty info. */
++int
+ get_tty_state ()
+ {
+   int tty;
+@@ -869,10 +872,12 @@ set_tty_state ()
+ }
+ 
+ /* Give the terminal to PGRP.  */
++int
+ give_terminal_to (pgrp, force)
+      pid_t pgrp;
+      int force;
+ {
++  return 0;
+ }
+ 
+ /* Stop a pipeline. */
+
+diff --git a/parse.y b/parse.y
+index 5211fbcb..f0cdfbf4 100644
+--- a/parse.y
++++ b/parse.y
+@@ -69,6 +69,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #  include "jobs.h"
++#else
++extern int cleanup_dead_jobs __P((void));
++extern int count_all_jobs __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #if defined (ALIAS)
+
+diff --git a/shell.c b/shell.c
+index 2fd8179b..45b77f9e 100644
+--- a/shell.c
++++ b/shell.c
+@@ -57,6 +59,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #include "jobs.h"
++#else
++extern int initialize_job_control __P((int));
++extern int get_tty_state __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #include "input.h"
+
+diff --git a/sig.c b/sig.c
+index 8bc45c17..d31ca87b 100644
+--- a/sig.c
++++ b/sig.c
+@@ -60,6 +60,12 @@ extern int executing_list;
+ extern int comsub_ignore_return;
+ extern int parse_and_execute_level, shell_initialized;
+ 
++extern void initialize_siglist ();
++
++#if !defined (JOB_CONTROL)
++extern void initialize_job_signals __P((void));
++#endif
++
+ /* Non-zero after SIGINT. */
+ volatile int interrupt_state = 0;
+ 
+
+diff --git a/siglist.h b/siglist.h
+index 4cb65308..bc0ea441 100644
+--- a/siglist.h
++++ b/siglist.h
+@@ -18,6 +18,8 @@
+    along with Bash.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <string.h>
++
+ #if !defined (_SIGLIST_H_)
+ #define _SIGLIST_H_
+ 
+
+diff --git a/subst.c b/subst.c
+index 089457fb..2e24ac4e 100644
+--- a/subst.c
++++ b/subst.c
+@@ -2625,6 +2625,7 @@ expand_assignment_string_to_string (string, quoted)
+ char *
+ expand_arith_string (string, quoted)
+      char *string;
++     int quoted;
+ {
+   return (expand_string_if_necessary (string, quoted, expand_string));
+ }
+
+diff --git a/support/bashversion.c b/support/bashversion.c
+index abf1aa8d..59c2321e 100644
+--- a/support/bashversion.c
++++ b/support/bashversion.c
+@@ -47,6 +47,9 @@ extern char *optarg;
+ extern char *dist_version;
+ extern int patch_level;
+ 
++extern char *shell_version_string __P((void));
++extern void show_shell_version __P((int));
++
+ char *shell_name = "bash";
+ char *progname;
+ 

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 # https://ftp.gnu.org/gnu/bash/?C=M;O=D
 ENV _BASH_VERSION 4.0.44
@@ -12,6 +12,8 @@ ENV _BASH_BASELINE 4.0
 # https://ftp.gnu.org/gnu/bash/bash-4.0-patches/?C=M;O=D
 ENV _BASH_LATEST_PATCH 44
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
+
+COPY alpine3.21.patch /usr/local/src/tianon-bash-patches/
 
 RUN set -eux; \
 	\
@@ -82,6 +84,14 @@ RUN set -eux; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	\
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 	\
 	cd /usr/local/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/4.0/alpine3.21.patch
+++ b/4.0/alpine3.21.patch
@@ -1,0 +1,152 @@
+Description: minor fixes for Alpine 3.21+
+Author: Tianon (& Chet, for fixes borrowed/backported)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 4ee59c11..2a3df6d6 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -57,6 +57,8 @@
+ extern int errno;
+ #endif
+ 
++#define NEED_FPURGE_DECL
++
+ #include "bashansi.h"
+ #include "bashintl.h"
+ 
+@@ -2061,6 +2120,7 @@ coproc_fdrestore (cp)
+ void
+ coproc_pidchk (pid, status)
+      pid_t pid;
++     int status;
+ {
+   struct coproc *cp;
+
+diff --git a/lib/readline/signals.c b/lib/readline/signals.c
+index 4fbc019e..6a68d78c 100644
+--- a/lib/readline/signals.c
++++ b/lib/readline/signals.c
+@@ -131,6 +131,7 @@ static sighandler_cxt old_winch;
+ /* Called from RL_CHECK_SIGNALS() macro */
+ RETSIGTYPE
+ _rl_signal_handler (sig)
++     int sig;
+ {
+   _rl_caught_signal = 0;       /* XXX */
+ 
+
+diff --git a/nojobs.c b/nojobs.c
+index 0c9bd751..fdbe0ae0 100644
+--- a/nojobs.c
++++ b/nojobs.c
+@@ -46,6 +46,7 @@
+ #include "shell.h"
+ #include "jobs.h"
+ #include "execute_cmd.h"
++#include "trap.h"
+ 
+ #include "builtins/builtext.h" /* for wait_builtin */
+ 
+@@ -410,6 +419,7 @@ reap_dead_jobs ()
+ }
+ 
+ /* Initialize the job control mechanism, and set up the tty stuff. */
++int
+ initialize_job_control (force)
+      int force;
+ {
+@@ -879,6 +933,7 @@ static TTYSTRUCT shell_tty_info;
+ static int got_tty_state;
+ 
+ /* Fill the contents of shell_tty_info with the current tty info. */
++int
+ get_tty_state ()
+ {
+   int tty;
+@@ -910,10 +966,12 @@ set_tty_state ()
+ }
+ 
+ /* Give the terminal to PGRP.  */
++int
+ give_terminal_to (pgrp, force)
+      pid_t pgrp;
+      int force;
+ {
++  return 0;
+ }
+ 
+ /* Stop a pipeline. */
+
+diff --git a/parse.y b/parse.y
+index 5211fbcb..f0cdfbf4 100644
+--- a/parse.y
++++ b/parse.y
+@@ -69,6 +69,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #  include "jobs.h"
++#else
++extern int cleanup_dead_jobs __P((void));
++extern int count_all_jobs __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #if defined (ALIAS)
+
+diff --git a/shell.c b/shell.c
+index 2fd8179b..45b77f9e 100644
+--- a/shell.c
++++ b/shell.c
+@@ -57,6 +59,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #include "jobs.h"
++#else
++extern int initialize_job_control __P((int));
++extern int get_tty_state __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #include "input.h"
+
+diff --git a/sig.c b/sig.c
+index 8bc45c17..d31ca87b 100644
+--- a/sig.c
++++ b/sig.c
+@@ -60,6 +60,12 @@ extern int executing_list;
+ extern int comsub_ignore_return;
+ extern int parse_and_execute_level, shell_initialized;
+ 
++extern void initialize_siglist ();
++
++#if !defined (JOB_CONTROL)
++extern void initialize_job_signals __P((void));
++#endif
++
+ /* Non-zero after SIGINT. */
+ volatile int interrupt_state = 0;
+ 
+diff --git a/siglist.c b/siglist.c
+index 27eb26a4..0e51b836 100644
+--- a/siglist.c
++++ b/siglist.c
+@@ -32,6 +32,7 @@
+ #  include "trap.h"
+ #endif
+ 
++#include "bashintl.h"
+ #include "xmalloc.h"
+ 
+ char *sys_siglist[NSIG];
+
+diff --git a/siglist.h b/siglist.h
+index 4cb65308..bc0ea441 100644
+--- a/siglist.h
++++ b/siglist.h
+@@ -18,6 +18,8 @@
+    along with Bash.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <string.h>
++
+ #if !defined (_SIGLIST_H_)
+ #define _SIGLIST_H_
+

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 # https://ftp.gnu.org/gnu/bash/?C=M;O=D
 ENV _BASH_VERSION 4.1.17
@@ -12,6 +12,8 @@ ENV _BASH_BASELINE 4.1
 # https://ftp.gnu.org/gnu/bash/bash-4.1-patches/?C=M;O=D
 ENV _BASH_LATEST_PATCH 17
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
+
+COPY alpine3.21.patch /usr/local/src/tianon-bash-patches/
 
 RUN set -eux; \
 	\
@@ -82,6 +84,14 @@ RUN set -eux; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	\
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 	\
 	cd /usr/local/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/4.1/alpine3.21.patch
+++ b/4.1/alpine3.21.patch
@@ -1,0 +1,130 @@
+Description: minor fixes for Alpine 3.21+
+Author: Tianon (& Chet, for fixes borrowed/backported)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 4ee59c11..2a3df6d6 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -2061,6 +2120,7 @@ coproc_fdrestore (cp)
+ void
+ coproc_pidchk (pid, status)
+      pid_t pid;
++     int status;
+ {
+   struct coproc *cp;
+
+diff --git a/lib/readline/signals.c b/lib/readline/signals.c
+index 4fbc019e..6a68d78c 100644
+--- a/lib/readline/signals.c
++++ b/lib/readline/signals.c
+@@ -131,6 +131,7 @@ static sighandler_cxt old_winch;
+ /* Called from RL_CHECK_SIGNALS() macro */
+ RETSIGTYPE
+ _rl_signal_handler (sig)
++     int sig;
+ {
+   _rl_caught_signal = 0;       /* XXX */
+ 
+
+diff --git a/nojobs.c b/nojobs.c
+index 0c9bd751..fdbe0ae0 100644
+--- a/nojobs.c
++++ b/nojobs.c
+@@ -46,6 +46,7 @@
+ #include "shell.h"
+ #include "jobs.h"
+ #include "execute_cmd.h"
++#include "trap.h"
+ 
+ #include "builtins/builtext.h" /* for wait_builtin */
+ 
+@@ -410,6 +419,7 @@ reap_dead_jobs ()
+ }
+ 
+ /* Initialize the job control mechanism, and set up the tty stuff. */
++int
+ initialize_job_control (force)
+      int force;
+ {
+@@ -879,6 +933,7 @@ static TTYSTRUCT shell_tty_info;
+ static int got_tty_state;
+ 
+ /* Fill the contents of shell_tty_info with the current tty info. */
++int
+ get_tty_state ()
+ {
+   int tty;
+@@ -910,10 +966,12 @@ set_tty_state ()
+ }
+ 
+ /* Give the terminal to PGRP.  */
++int
+ give_terminal_to (pgrp, force)
+      pid_t pgrp;
+      int force;
+ {
++  return 0;
+ }
+ 
+ /* Stop a pipeline. */
+
+diff --git a/parse.y b/parse.y
+index 5211fbcb..f0cdfbf4 100644
+--- a/parse.y
++++ b/parse.y
+@@ -69,6 +69,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #  include "jobs.h"
++#else
++extern int cleanup_dead_jobs __P((void));
++extern int count_all_jobs __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #if defined (ALIAS)
+
+diff --git a/shell.c b/shell.c
+index 2fd8179b..45b77f9e 100644
+--- a/shell.c
++++ b/shell.c
+@@ -57,6 +59,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #include "jobs.h"
++#else
++extern int initialize_job_control __P((int));
++extern int get_tty_state __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #include "input.h"
+
+diff --git a/sig.c b/sig.c
+index 8bc45c17..d31ca87b 100644
+--- a/sig.c
++++ b/sig.c
+@@ -60,6 +60,12 @@ extern int executing_list;
+ extern int comsub_ignore_return;
+ extern int parse_and_execute_level, shell_initialized;
+ 
++extern void initialize_siglist ();
++
++#if !defined (JOB_CONTROL)
++extern void initialize_job_signals __P((void));
++#endif
++
+ /* Non-zero after SIGINT. */
+ volatile int interrupt_state = 0;
+ 
+diff --git a/siglist.h b/siglist.h
+index 4cb65308..bc0ea441 100644
+--- a/siglist.h
++++ b/siglist.h
+@@ -18,6 +18,8 @@
+    along with Bash.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <string.h>
++
+ #if !defined (_SIGLIST_H_)
+ #define _SIGLIST_H_
+

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 # https://ftp.gnu.org/gnu/bash/?C=M;O=D
 ENV _BASH_VERSION 4.2.53
@@ -13,6 +13,8 @@ ENV _BASH_BASELINE_PATCH 53
 # https://ftp.gnu.org/gnu/bash/bash-4.2-patches/?C=M;O=D
 ENV _BASH_LATEST_PATCH 53
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
+
+COPY alpine3.21.patch /usr/local/src/tianon-bash-patches/
 
 RUN set -eux; \
 	\
@@ -83,6 +85,14 @@ RUN set -eux; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	\
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 	\
 	cd /usr/local/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/4.2/alpine3.21.patch
+++ b/4.2/alpine3.21.patch
@@ -1,0 +1,115 @@
+Description: minor fixes for Alpine 3.21+
+Author: Tianon (& Chet, for fixes borrowed/backported)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 4ee59c11..2a3df6d6 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -2061,6 +2120,7 @@ coproc_fdrestore (cp)
+ void
+ coproc_pidchk (pid, status)
+      pid_t pid;
++     int status;
+ {
+   struct coproc *cp;
+
+diff --git a/nojobs.c b/nojobs.c
+index 0c9bd751..fdbe0ae0 100644
+--- a/nojobs.c
++++ b/nojobs.c
+@@ -46,6 +46,7 @@
+ #include "shell.h"
+ #include "jobs.h"
+ #include "execute_cmd.h"
++#include "trap.h"
+ 
+ #include "builtins/builtext.h" /* for wait_builtin */
+ 
+@@ -410,6 +419,7 @@ reap_dead_jobs ()
+ }
+ 
+ /* Initialize the job control mechanism, and set up the tty stuff. */
++int
+ initialize_job_control (force)
+      int force;
+ {
+@@ -879,6 +933,7 @@ static TTYSTRUCT shell_tty_info;
+ static int got_tty_state;
+ 
+ /* Fill the contents of shell_tty_info with the current tty info. */
++int
+ get_tty_state ()
+ {
+   int tty;
+@@ -910,10 +966,12 @@ set_tty_state ()
+ }
+ 
+ /* Give the terminal to PGRP.  */
++int
+ give_terminal_to (pgrp, force)
+      pid_t pgrp;
+      int force;
+ {
++  return 0;
+ }
+ 
+ /* Stop a pipeline. */
+
+diff --git a/parse.y b/parse.y
+index 5211fbcb..f0cdfbf4 100644
+--- a/parse.y
++++ b/parse.y
+@@ -69,6 +69,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #  include "jobs.h"
++#else
++extern int cleanup_dead_jobs __P((void));
++extern int count_all_jobs __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #if defined (ALIAS)
+
+diff --git a/shell.c b/shell.c
+index 2fd8179b..45b77f9e 100644
+--- a/shell.c
++++ b/shell.c
+@@ -57,6 +59,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #include "jobs.h"
++#else
++extern int initialize_job_control __P((int));
++extern int get_tty_state __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #include "input.h"
+
+diff --git a/sig.c b/sig.c
+index 8bc45c17..d31ca87b 100644
+--- a/sig.c
++++ b/sig.c
+@@ -70,6 +70,10 @@ extern sh_builtin_func_t *this_shell_builtin;
+ 
+ extern void initialize_siglist ();
+ 
++#if !defined (JOB_CONTROL)
++extern void initialize_job_signals __P((void));
++#endif
++
+ /* Non-zero after SIGINT. */
+ volatile sig_atomic_t interrupt_state = 0;
+ 
+diff --git a/siglist.h b/siglist.h
+index 4cb65308..bc0ea441 100644
+--- a/siglist.h
++++ b/siglist.h
+@@ -18,6 +18,8 @@
+    along with Bash.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <string.h>
++
+ #if !defined (_SIGLIST_H_)
+ #define _SIGLIST_H_
+

--- a/4.3/Dockerfile
+++ b/4.3/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 # https://ftp.gnu.org/gnu/bash/?C=M;O=D
 ENV _BASH_VERSION 4.3.48
@@ -13,6 +13,8 @@ ENV _BASH_BASELINE_PATCH 30
 # https://ftp.gnu.org/gnu/bash/bash-4.3-patches/?C=M;O=D
 ENV _BASH_LATEST_PATCH 48
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
+
+COPY alpine3.21.patch /usr/local/src/tianon-bash-patches/
 
 RUN set -eux; \
 	\
@@ -83,6 +85,14 @@ RUN set -eux; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	\
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 	\
 	cd /usr/local/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/4.3/alpine3.21.patch
+++ b/4.3/alpine3.21.patch
@@ -1,0 +1,141 @@
+Description: minor fixes for Alpine 3.21+
+Author: Tianon (& Chet, for fixes borrowed/backported)
+
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 4ee59c11..2a3df6d6 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -2061,6 +2120,7 @@ coproc_fdrestore (cp)
+ void
+ coproc_pidchk (pid, status)
+      pid_t pid;
++     int status;
+ {
+   struct coproc *cp;
+
+diff --git a/nojobs.c b/nojobs.c
+index 0c9bd751..fdbe0ae0 100644
+--- a/nojobs.c
++++ b/nojobs.c
+@@ -46,6 +46,7 @@
+ #include "shell.h"
+ #include "jobs.h"
+ #include "execute_cmd.h"
++#include "trap.h"
+ 
+ #include "builtins/builtext.h" /* for wait_builtin */
+ 
+@@ -410,6 +419,7 @@ reap_dead_jobs ()
+ }
+ 
+ /* Initialize the job control mechanism, and set up the tty stuff. */
++int
+ initialize_job_control (force)
+      int force;
+ {
+@@ -879,6 +933,7 @@ static TTYSTRUCT shell_tty_info;
+ static int got_tty_state;
+ 
+ /* Fill the contents of shell_tty_info with the current tty info. */
++int
+ get_tty_state ()
+ {
+   int tty;
+@@ -910,10 +966,12 @@ set_tty_state ()
+ }
+ 
+ /* Give the terminal to PGRP.  */
++int
+ give_terminal_to (pgrp, force)
+      pid_t pgrp;
+      int force;
+ {
++  return 0;
+ }
+ 
+ /* Stop a pipeline. */
+
+diff --git a/parse.y b/parse.y
+index 5211fbcb..f0cdfbf4 100644
+--- a/parse.y
++++ b/parse.y
+@@ -69,6 +69,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #  include "jobs.h"
++#else
++extern int cleanup_dead_jobs __P((void));
++extern int count_all_jobs __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #if defined (ALIAS)
+
+diff --git a/redir.c b/redir.c
+index e514976d..25488eaf 100644
+--- a/redir.c
++++ b/redir.c
+@@ -52,6 +52,7 @@ extern int errno;
+ #include "flags.h"
+ #include "execute_cmd.h"
+ #include "redir.h"
++#include "trap.h"
+ 
+ #if defined (BUFFERED_INPUT)
+ #  include "input.h"
+
+diff --git a/shell.c b/shell.c
+index 2fd8179b..45b77f9e 100644
+--- a/shell.c
++++ b/shell.c
+@@ -57,6 +59,9 @@
+ 
+ #if defined (JOB_CONTROL)
+ #include "jobs.h"
++#else
++extern int initialize_job_control __P((int));
++extern int get_tty_state __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #include "input.h"
+
+diff --git a/sig.c b/sig.c
+index 8bc45c17..d31ca87b 100644
+--- a/sig.c
++++ b/sig.c
+@@ -70,6 +70,10 @@ extern sh_builtin_func_t *this_shell_builtin;
+ 
+ extern void initialize_siglist ();
+ 
++#if !defined (JOB_CONTROL)
++extern void initialize_job_signals __P((void));
++#endif
++
+ /* Non-zero after SIGINT. */
+ volatile sig_atomic_t interrupt_state = 0;
+ 
+diff --git a/siglist.h b/siglist.h
+index 4cb65308..bc0ea441 100644
+--- a/siglist.h
++++ b/siglist.h
+@@ -18,6 +18,8 @@
+    along with Bash.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <string.h>
++
+ #if !defined (_SIGLIST_H_)
+ #define _SIGLIST_H_
+
+diff --git a/variables.c b/variables.c
+index 51aaf9cd..0ec7b5d6 100644
+--- a/variables.c
++++ b/variables.c
+@@ -2573,7 +2573,7 @@ bind_variable_internal (name, value, table, hflags, aflags)
+       entry = make_new_array_variable (newname);	/* indexed array by default */
+       if (entry == 0)
+ 	return entry;
+-      ind = array_expand_index (name, subp, sublen);
++      ind = array_expand_index (entry, subp, sublen);
+       bind_array_element (entry, ind, value, aflags);
+     }
+ #endif

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 # https://ftp.gnu.org/gnu/bash/?C=M;O=D
 ENV _BASH_VERSION 4.4.23
@@ -13,6 +13,8 @@ ENV _BASH_BASELINE_PATCH 18
 # https://ftp.gnu.org/gnu/bash/bash-4.4-patches/?C=M;O=D
 ENV _BASH_LATEST_PATCH 23
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
+
+COPY alpine3.21.patch /usr/local/src/tianon-bash-patches/
 
 RUN set -eux; \
 	\
@@ -83,6 +85,14 @@ RUN set -eux; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	\
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 	\
 	cd /usr/local/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/4.4/alpine3.21.patch
+++ b/4.4/alpine3.21.patch
@@ -1,0 +1,28 @@
+Description: minor fixes for Alpine 3.21+
+Author: Tianon (& Chet, for fixes borrowed/backported)
+
+diff --git a/parse.y b/parse.y
+index f415d2ee..e59dbed9 100644
+--- a/parse.y
++++ b/parse.y
+@@ -71,6 +71,7 @@
+ #  include "jobs.h"
+ #else
+ extern int cleanup_dead_jobs __P((void));
++extern int count_all_jobs __P((void));
+ #endif /* JOB_CONTROL */
+ 
+ #if defined (ALIAS)
+
+diff --git a/siglist.h b/siglist.h
+index 4cb65308..bc0ea441 100644
+--- a/siglist.h
++++ b/siglist.h
+@@ -18,6 +18,8 @@
+    along with Bash.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <string.h>
++
+ #if !defined (_SIGLIST_H_)
+ #define _SIGLIST_H_

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.20
+FROM alpine:3.21
 
 # https://ftp.gnu.org/gnu/bash/?C=M;O=D
 ENV _BASH_VERSION 5.0.18
@@ -12,6 +12,8 @@ ENV _BASH_BASELINE 5.0
 # https://ftp.gnu.org/gnu/bash/bash-5.0-patches/?C=M;O=D
 ENV _BASH_LATEST_PATCH 18
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
+
+COPY alpine3.21.patch /usr/local/src/tianon-bash-patches/
 
 RUN set -eux; \
 	\
@@ -82,6 +84,14 @@ RUN set -eux; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
+	\
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 	\
 	cd /usr/local/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/5.0/alpine3.21.patch
+++ b/5.0/alpine3.21.patch
@@ -1,0 +1,15 @@
+Description: minor fixes for Alpine 3.21+
+Author: Tianon
+
+diff --git a/siglist.h b/siglist.h
+index 4cb65308..bc0ea441 100644
+--- a/siglist.h
++++ b/siglist.h
+@@ -18,6 +18,8 @@
+    along with Bash.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
++#include <string.h>
++
+ #if !defined (_SIGLIST_H_)
+ #define _SIGLIST_H_

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -19,6 +19,10 @@ ENV _BASH_LATEST_PATCH {{ .patch.version }}
 {{ ) end -}}
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+{{ if env.patches != "" then ( -}}
+COPY {{ env.patches | split("\n") | map(ltrimstr("./")) | join(" ") }} /usr/local/src/tianon-bash-patches/
+
+{{ ) else "" end -}}
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
@@ -92,11 +96,15 @@ RUN set -eux; \
 		rmdir bash-patches; \
 		apk del --no-network .patch-deps; \
 	fi; \
-{{ if env.version == "devel" then ( -}}
+{{ if env.patches != "" then ( -}}
 	\
-# https://lists.gnu.org/archive/html/bug-bash/2023-05/msg00011.html
-	{ echo '#include <unistd.h>'; echo; cat /usr/local/src/bash/lib/sh/strscpy.c; } > /usr/local/src/bash/lib/sh/strscpy.c.new; \
-	mv /usr/local/src/bash/lib/sh/strscpy.c.new /usr/local/src/bash/lib/sh/strscpy.c; \
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 {{ ) else "" end -}}
 	\
 	cd /usr/local/src/bash; \

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -32,6 +32,9 @@ for version; do
 
 	echo "processing $version ..."
 
+	patches="$(cd "$version" && find -maxdepth 1 -name '*.patch' -type f | LC_ALL=C sort)"
+	export patches
+
 	{
 		generated_warning
 		gawk -f "$jqt" Dockerfile.template

--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -12,6 +12,8 @@ ENV _BASH_COMMIT 49c2670226b045746d66765b23af37c1c7ba5597
 ENV _BASH_VERSION devel-20241126
 # prefixed with "_" since "$BASH..." have meaning in Bash parlance
 
+COPY alpine-strcpy.patch /usr/local/src/tianon-bash-patches/
+
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \
@@ -51,9 +53,13 @@ RUN set -eux; \
 		apk del --no-network .patch-deps; \
 	fi; \
 	\
-# https://lists.gnu.org/archive/html/bug-bash/2023-05/msg00011.html
-	{ echo '#include <unistd.h>'; echo; cat /usr/local/src/bash/lib/sh/strscpy.c; } > /usr/local/src/bash/lib/sh/strscpy.c.new; \
-	mv /usr/local/src/bash/lib/sh/strscpy.c.new /usr/local/src/bash/lib/sh/strscpy.c; \
+	for p in /usr/local/src/tianon-bash-patches/*; do \
+		patch \
+			--directory=/usr/local/src/bash \
+			--input="$p" \
+			--strip=1 \
+		; \
+	done; \
 	\
 	cd /usr/local/src/bash; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \

--- a/devel/alpine-strcpy.patch
+++ b/devel/alpine-strcpy.patch
@@ -1,0 +1,17 @@
+Description: fix Alpine ssize_t vs size_t bug
+Author: Emanuele Torre
+Origin: https://lists.gnu.org/archive/html/bug-bash/2023-05/msg00011.html
+
+diff --git a/lib/sh/strscpy.c b/lib/sh/strscpy.c
+index 7a948ebe..e2679e95 100644
+--- a/lib/sh/strscpy.c
++++ b/lib/sh/strscpy.c
+@@ -22,6 +22,8 @@
+ 
+ #include <bashansi.h>
+ 
++#include <unistd.h>
++
+ ssize_t
+ strscpy (char *d, const char *s, size_t len)
+ {

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
   "3.0": {
     "alpine": {
-      "version": "3.20"
+      "version": "3.21"
     },
     "baseline": {
       "patch": "16",
@@ -14,7 +14,7 @@
   },
   "3.1": {
     "alpine": {
-      "version": "3.20"
+      "version": "3.21"
     },
     "baseline": {
       "version": "3.1"
@@ -26,7 +26,7 @@
   },
   "3.2": {
     "alpine": {
-      "version": "3.20"
+      "version": "3.21"
     },
     "baseline": {
       "patch": "57"
@@ -38,7 +38,7 @@
   },
   "4.0": {
     "alpine": {
-      "version": "3.20"
+      "version": "3.21"
     },
     "baseline": {
       "version": "4.0"
@@ -50,7 +50,7 @@
   },
   "4.1": {
     "alpine": {
-      "version": "3.20"
+      "version": "3.21"
     },
     "baseline": {
       "version": "4.1"
@@ -62,7 +62,7 @@
   },
   "4.2": {
     "alpine": {
-      "version": "3.20"
+      "version": "3.21"
     },
     "baseline": {
       "patch": "53"
@@ -74,7 +74,7 @@
   },
   "4.3": {
     "alpine": {
-      "version": "3.20"
+      "version": "3.21"
     },
     "baseline": {
       "patch": "30",
@@ -87,7 +87,7 @@
   },
   "4.4": {
     "alpine": {
-      "version": "3.20"
+      "version": "3.21"
     },
     "baseline": {
       "patch": "18",
@@ -100,7 +100,7 @@
   },
   "5.0": {
     "alpine": {
-      "version": "3.20"
+      "version": "3.21"
     },
     "baseline": {
       "version": "5.0"


### PR DESCRIPTION
This also includes support for per-version patches, and converts some hacky code we had for devel to a proper patch file.

My intent is to keep all these patches minimal -- any non-minimal patching (especially anything beyond "make it compile successfully") will likely be grounds for no longer supporting a given version.

Almost all of these patches are cobbled together from later commits in Bash upstream (ie, backported fixes).  Only one or two are actually pure-Tianon creations (and those are just `#include <something.h>`).