### PR TITLE
Fix missing Job Control builtins in Bash 3.0-4.3 and stabilize Bash 3.x builds

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -100,6 +100,8 @@ RUN set -eux; \
 	for f in config.guess config.sub; do \
 		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
 	done; \
+# https://github.com/tianon/docker-bash/pull/45
+	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-readline \
@@ -113,7 +115,7 @@ RUN set -eux; \
 	}; \
 # parallel jobs workaround borrowed from Alpine :)
 	make y.tab.c; make builtins/libbuiltins.a; \
-	make -j "$(nproc)"; \
+	make -j 1; \
 	make install; \
 	cd /; \
 	rm -r /usr/local/src/bash; \

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -99,6 +99,8 @@ RUN set -eux; \
 	for f in config.guess config.sub; do \
 		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
 	done; \
+# https://github.com/tianon/docker-bash/pull/45
+	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-readline \
@@ -112,7 +114,7 @@ RUN set -eux; \
 	}; \
 # parallel jobs workaround borrowed from Alpine :)
 	make y.tab.c; make builtins/libbuiltins.a; \
-	make -j "$(nproc)"; \
+	make -j 1; \
 	make install; \
 	cd /; \
 	rm -r /usr/local/src/bash; \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -100,6 +100,8 @@ RUN set -eux; \
 	for f in config.guess config.sub; do \
 		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
 	done; \
+# https://github.com/tianon/docker-bash/pull/45
+	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-readline \
@@ -113,7 +115,7 @@ RUN set -eux; \
 	}; \
 # parallel jobs workaround borrowed from Alpine :)
 	make y.tab.c; make builtins/libbuiltins.a; \
-	make -j "$(nproc)"; \
+	make -j 1; \
 	make install; \
 	cd /; \
 	rm -r /usr/local/src/bash; \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -99,6 +99,8 @@ RUN set -eux; \
 	for f in config.guess config.sub; do \
 		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
 	done; \
+# https://github.com/tianon/docker-bash/pull/45
+	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-readline \

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -99,6 +99,8 @@ RUN set -eux; \
 	for f in config.guess config.sub; do \
 		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
 	done; \
+# https://github.com/tianon/docker-bash/pull/45
+	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-readline \

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -100,6 +100,8 @@ RUN set -eux; \
 	for f in config.guess config.sub; do \
 		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
 	done; \
+# https://github.com/tianon/docker-bash/pull/45
+	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-readline \

--- a/4.3/Dockerfile
+++ b/4.3/Dockerfile
@@ -100,6 +100,8 @@ RUN set -eux; \
 	for f in config.guess config.sub; do \
 		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
 	done; \
+# https://github.com/tianon/docker-bash/pull/45
+	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \
 	./configure \
 		--build="$gnuArch" \
 		--enable-readline \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -115,6 +115,10 @@ RUN set -eux; \
 		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
 	done; \
 {{ ) end -}}
+{{ if env.version | IN("3.0", "3.1", "3.2", "4.0", "4.1", "4.2", "4.3") then ( -}}
+# https://github.com/tianon/docker-bash/pull/45
+	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \
+{{ ) else "" end -}}
 	./configure \
 		--build="$gnuArch" \
 		--enable-readline \
@@ -135,7 +139,11 @@ RUN set -eux; \
 # parallel jobs workaround borrowed from Alpine :)
 	make y.tab.c; make builtins/libbuiltins.a; \
 {{ ) end -}}
+{{ if env.version | startswith("3.") then ( -}}
+	make -j 1; \
+{{ ) else ( -}}
 	make -j "$(nproc)"; \
+{{ ) end -}}
 	make install; \
 	cd /; \
 	rm -r /usr/local/src/bash; \


### PR DESCRIPTION
This PR fixes missing Job Control commands (`bg`, `disown`, `fg`, `jobs`) in Bash 3.0–4.3 images.

#### Problem
The latest Bash 3.0–4.3 images do not include Job Control builtins. Steps to reproduce with `bash:4.3 (amd64)`:

```sh
docker run --rm bash:4.3@sha256:53abafff8451a86fbb1758af492e5b31740c8f0bc86cf074fbc3d73cbb78e08f -c 'type bg disown fg jobs'
# docker run --rm bash:4.3 -c 'type bg disown fg jobs'
```

Output:
```
bash: line 0: type: bg: not found
bash: line 0: type: disown: not found
bash: line 0: type: fg: not found
bash: line 0: type: jobs: not found
```

The previous image version(amd64) works as expected:

```sh
docker run --rm bash:4.3@sha256:901dc91dfb31a49d5264020556b41bf6e83dd36d879fc745d629d4d3f98210ab -c 'type bg disown fg jobs'
```

Output:
```
bg is a shell builtin
disown is a shell builtin
fg is a shell builtin
jobs is a shell builtin
```

The issue occurs across all Bash 3.0–4.3 images.

Additional Fix

Building Bash 3.x images with parallel jobs causes intermittent failures, such as:
- `ar: savestring.o: No such file or directory`
- `ar: mbutil.o: No such file or directory`
-  ...

Building Bash 3.x with a single thread avoids these failures. This PR adjusts the build process to ensure stability.

Changes
1. Restore Job Control functionality for Bash 3.0–4.3.
2. Disable parallel builds for Bash 3.x to prevent build failures.

