### PR TITLE
Fall back to my mirrors when fetching from savannah.gnu.org fails

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -98,7 +98,8 @@ RUN set -eux; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 # update "config.guess" and "config.sub" to get more aggressively inclusive architecture support
 	for f in config.guess config.sub; do \
-		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
+		wget -T2 -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb" || \
+			wget -O "support/$f" "https://github.com/tianon/mirror-gnu-config/raw/7d3d27baf8107b630586c962c057e22149653deb/$f"; \
 	done; \
 # https://github.com/tianon/docker-bash/pull/45
 	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \

--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -97,7 +97,8 @@ RUN set -eux; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 # update "config.guess" and "config.sub" to get more aggressively inclusive architecture support
 	for f in config.guess config.sub; do \
-		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
+		wget -T2 -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb" || \
+			wget -O "support/$f" "https://github.com/tianon/mirror-gnu-config/raw/7d3d27baf8107b630586c962c057e22149653deb/$f"; \
 	done; \
 # https://github.com/tianon/docker-bash/pull/45
 	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -98,7 +98,8 @@ RUN set -eux; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 # update "config.guess" and "config.sub" to get more aggressively inclusive architecture support
 	for f in config.guess config.sub; do \
-		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
+		wget -T2 -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb" || \
+			wget -O "support/$f" "https://github.com/tianon/mirror-gnu-config/raw/7d3d27baf8107b630586c962c057e22149653deb/$f"; \
 	done; \
 # https://github.com/tianon/docker-bash/pull/45
 	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -97,7 +97,8 @@ RUN set -eux; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 # update "config.guess" and "config.sub" to get more aggressively inclusive architecture support
 	for f in config.guess config.sub; do \
-		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
+		wget -T2 -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb" || \
+			wget -O "support/$f" "https://github.com/tianon/mirror-gnu-config/raw/7d3d27baf8107b630586c962c057e22149653deb/$f"; \
 	done; \
 # https://github.com/tianon/docker-bash/pull/45
 	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -97,7 +97,8 @@ RUN set -eux; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 # update "config.guess" and "config.sub" to get more aggressively inclusive architecture support
 	for f in config.guess config.sub; do \
-		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
+		wget -T2 -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb" || \
+			wget -O "support/$f" "https://github.com/tianon/mirror-gnu-config/raw/7d3d27baf8107b630586c962c057e22149653deb/$f"; \
 	done; \
 # https://github.com/tianon/docker-bash/pull/45
 	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \

--- a/4.2/Dockerfile
+++ b/4.2/Dockerfile
@@ -98,7 +98,8 @@ RUN set -eux; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 # update "config.guess" and "config.sub" to get more aggressively inclusive architecture support
 	for f in config.guess config.sub; do \
-		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
+		wget -T2 -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb" || \
+			wget -O "support/$f" "https://github.com/tianon/mirror-gnu-config/raw/7d3d27baf8107b630586c962c057e22149653deb/$f"; \
 	done; \
 # https://github.com/tianon/docker-bash/pull/45
 	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \

--- a/4.3/Dockerfile
+++ b/4.3/Dockerfile
@@ -98,7 +98,8 @@ RUN set -eux; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 # update "config.guess" and "config.sub" to get more aggressively inclusive architecture support
 	for f in config.guess config.sub; do \
-		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
+		wget -T2 -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb" || \
+			wget -O "support/$f" "https://github.com/tianon/mirror-gnu-config/raw/7d3d27baf8107b630586c962c057e22149653deb/$f"; \
 	done; \
 # https://github.com/tianon/docker-bash/pull/45
 	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \

--- a/4.4/Dockerfile
+++ b/4.4/Dockerfile
@@ -98,7 +98,8 @@ RUN set -eux; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 # update "config.guess" and "config.sub" to get more aggressively inclusive architecture support
 	for f in config.guess config.sub; do \
-		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
+		wget -T2 -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb" || \
+			wget -O "support/$f" "https://github.com/tianon/mirror-gnu-config/raw/7d3d27baf8107b630586c962c057e22149653deb/$f"; \
 	done; \
 # https://github.com/tianon/docker-bash/pull/45
 	export CFLAGS='-Wno-error=implicit-int -Wno-error=implicit-function-declaration'; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,6 +2,7 @@ FROM alpine:{{ .alpine.version }}
 
 {{ if env.version == "devel" then ( -}}
 # https://git.savannah.gnu.org/cgit/bash.git/log/?h=devel
+# https://github.com/tianon/mirror-bash/commits/devel
 ENV _BASH_COMMIT {{ .commit.version }}
 # {{ .commit.description }}
 ENV _BASH_VERSION devel-{{ .version }}
@@ -38,7 +39,8 @@ RUN set -eux; \
 	; \
 	\
 {{ if env.version == "devel" then ( -}}
-	wget -O bash.tar.gz "https://git.savannah.gnu.org/cgit/bash.git/snapshot/bash-$_BASH_COMMIT.tar.gz"; \
+	wget -T2 -O bash.tar.gz "https://git.savannah.gnu.org/cgit/bash.git/snapshot/bash-$_BASH_COMMIT.tar.gz" || \
+		wget -O bash.tar.gz "https://github.com/tianon/mirror-bash/archive/$_BASH_COMMIT.tar.gz"; \
 {{ ) else ( -}}
 	wget -O bash.tar.gz "https://ftp.gnu.org/gnu/bash/bash-$_BASH_BASELINE.tar.gz"; \
 	wget -O bash.tar.gz.sig "https://ftp.gnu.org/gnu/bash/bash-$_BASH_BASELINE.tar.gz.sig"; \
@@ -112,7 +114,8 @@ RUN set -eux; \
 {{ if env.version == "devel" or (env.version | split(".") | .[0] | tonumber) >= 5 then "" else ( -}}
 # update "config.guess" and "config.sub" to get more aggressively inclusive architecture support
 	for f in config.guess config.sub; do \
-		wget -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb"; \
+		wget -T2 -O "support/$f" "https://git.savannah.gnu.org/cgit/config.git/plain/$f?id=7d3d27baf8107b630586c962c057e22149653deb" || \
+			wget -O "support/$f" "https://github.com/tianon/mirror-gnu-config/raw/7d3d27baf8107b630586c962c057e22149653deb/$f"; \
 	done; \
 {{ ) end -}}
 {{ if env.version | IN("3.0", "3.1", "3.2", "4.0", "4.1", "4.2", "4.3", "4.4") then ( -}}

--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -7,6 +7,7 @@
 FROM alpine:3.22
 
 # https://git.savannah.gnu.org/cgit/bash.git/log/?h=devel
+# https://github.com/tianon/mirror-bash/commits/devel
 ENV _BASH_COMMIT b35866a2891a9b069e37ca5684d4309c0391e261
 # updated translations; documentation updates; update copyright dates
 ENV _BASH_VERSION devel-20250627
@@ -28,7 +29,8 @@ RUN set -eux; \
 		tar \
 	; \
 	\
-	wget -O bash.tar.gz "https://git.savannah.gnu.org/cgit/bash.git/snapshot/bash-$_BASH_COMMIT.tar.gz"; \
+	wget -T2 -O bash.tar.gz "https://git.savannah.gnu.org/cgit/bash.git/snapshot/bash-$_BASH_COMMIT.tar.gz" || \
+		wget -O bash.tar.gz "https://github.com/tianon/mirror-bash/archive/$_BASH_COMMIT.tar.gz"; \
 	\
 	mkdir -p /usr/local/src/bash; \
 	tar \


### PR DESCRIPTION
All these fetches happen via full commit hashes, so should be reasonably safe.