### PR TITLE
Add better commit extraction logic to handle gnu.org glitches

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -68,14 +68,12 @@ for version in "${versions[@]}"; do
 					| jq -r '
 						.feed.entry[]
 						| (
-							.id
-							| if startswith("urn:sha1:") then
-								# cgit
-								ltrimstr("urn:sha1:")
-							elif contains(":Commit/") then
-								# github
-								sub("^.*:Commit/"; "")
-							else null end
+							"[0-9a-f]{40}" as $commitRegex
+							| "(^|[:/=])(?<commit>\($commitRegex))([&/:]|$)" as $captureRegex
+							| (.id | capture($captureRegex))
+							// (.link."+@href" | capture($captureRegex))
+							// {}
+							| .commit
 						) as $commit
 						| select(
 							$commit


### PR DESCRIPTION
Upstream's server is clearly "going through it" and keeps swapping back and forth across this diff:

```diff
--- broken.xml	2025-08-27 11:01:24.171030930 -0700
+++ correct.xml	2025-08-27 10:37:05.844443959 -0700
@@ -1,7 +1,10 @@
 <feed xmlns='http://www.w3.org/2005/Atom'>
 <title>bash.git, branch devel</title>
 <subtitle>bash</subtitle>
+<id>https://cgit.git.savannah.gnu.org/cgit/bash.git/atom?h=devel</id>
+<link rel='self' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/atom?h=devel'/>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/'/>
+<updated>2025-08-22T20:10:45+00:00</updated>
 <entry>
 <title>fix for rare readline case where read(2) succeeds but also gets a signal as it is returning to user mode; fix for bash completion filename quoting when there is more than one match</title>
 <updated>2025-08-22T20:10:45+00:00</updated>
@@ -11,15 +14,9 @@
 </author>
 <published>2025-08-22T20:10:45+00:00</published>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=ab17ddb7af948ee6e1a6370aac4ee57b4179cd9c'/>
-<id>ab17ddb7af948ee6e1a6370aac4ee57b4179cd9c</id>
+<id>urn:sha1:ab17ddb7af948ee6e1a6370aac4ee57b4179cd9c</id>
 <content type='text'>
 </content>
-<content type='xhtml'>
-<div xmlns='http://www.w3.org/1999/xhtml'>
-<pre>
-</pre>
-</div>
-</content>
 </entry>
 <entry>
 <title>fix for nofork comsubs undoing enclosing command's redirections; fix for binding _ variable in the temporary environment; fix for crash when making special variables arrays; accommodate IFS as array variable; fix for SIGINT arriving while cleaning up a readline incremental search</title>
@@ -30,15 +27,9 @@
 </author>
 <published>2025-08-20T15:08:28+00:00</published>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=086456835944d1a3098a026646144573deafc917'/>
-<id>086456835944d1a3098a026646144573deafc917</id>
+<id>urn:sha1:086456835944d1a3098a026646144573deafc917</id>
 <content type='text'>
 </content>
-<content type='xhtml'>
-<div xmlns='http://www.w3.org/1999/xhtml'>
-<pre>
-</pre>
-</div>
-</content>
 </entry>
 <entry>
 <title>fix issue with break in nofork comsub when expanding for command word list; add error message if the value of a nameref variable expands to an invalid variable name</title>
@@ -49,15 +40,9 @@
 </author>
 <published>2025-08-14T14:27:52+00:00</published>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=3160c0b89ce4f3934e791de94f9370b6cfc26ae5'/>
-<id>3160c0b89ce4f3934e791de94f9370b6cfc26ae5</id>
+<id>urn:sha1:3160c0b89ce4f3934e791de94f9370b6cfc26ae5</id>
 <content type='text'>
 </content>
-<content type='xhtml'>
-<div xmlns='http://www.w3.org/1999/xhtml'>
-<pre>
-</pre>
-</div>
-</content>
 </entry>
 <entry>
 <title>allow the --with-curses configure argument to specify a library name; fix for case pattern lists containing both null and non-null strings; fix for bug with PS1 expansion containing an arithmetic syntax error</title>
@@ -68,15 +53,9 @@
 </author>
 <published>2025-08-08T16:11:17+00:00</published>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=ff6cfb1464a39b964204a4f83caab2b8484829a6'/>
-<id>ff6cfb1464a39b964204a4f83caab2b8484829a6</id>
+<id>urn:sha1:ff6cfb1464a39b964204a4f83caab2b8484829a6</id>
 <content type='text'>
 </content>
-<content type='xhtml'>
-<div xmlns='http://www.w3.org/1999/xhtml'>
-<pre>
-</pre>
-</div>
-</content>
 </entry>
 <entry>
 <title>fix for parameter expansions that contain valid and invalid expansions; avoid stale readdir() value in getcwd replacement; check libtinfow for termcap functions; fix to propagate exit status of builtins run in subshells back to calling shell</title>
@@ -87,15 +66,9 @@
 </author>
 <published>2025-08-04T14:18:32+00:00</published>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=e9053f2a3ae4ed638d269481626e0e5408ae8965'/>
-<id>e9053f2a3ae4ed638d269481626e0e5408ae8965</id>
+<id>urn:sha1:e9053f2a3ae4ed638d269481626e0e5408ae8965</id>
 <content type='text'>
 </content>
-<content type='xhtml'>
-<div xmlns='http://www.w3.org/1999/xhtml'>
-<pre>
-</pre>
-</div>
-</content>
 </entry>
 <entry>
 <title>history library can now read history from non-regular files; fix for readline char search and macros; better fix for PROMPT_COMMAND and aliases ending in newlines; fix for casting COMMAND * and SIMPLE_COM * when parsing |&amp;; fix to avoid undefined behavior when performing left and right arithmetic shifts</title>
@@ -106,15 +79,9 @@
 </author>
 <published>2025-08-01T20:26:31+00:00</published>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=c1d9c088531eef0797e78c66b899d895862de80c'/>
-<id>c1d9c088531eef0797e78c66b899d895862de80c</id>
+<id>urn:sha1:c1d9c088531eef0797e78c66b899d895862de80c</id>
 <content type='text'>
 </content>
-<content type='xhtml'>
-<div xmlns='http://www.w3.org/1999/xhtml'>
-<pre>
-</pre>
-</div>
-</content>
 </entry>
 <entry>
 <title>fix for `wait -n' in posix mode; fix for long messages in readline; fix for short reads by `source' builtin; fix for crash on RISC-V machines; fix for bad memory read when getopts is called twice with different sets of arguments</title>
@@ -125,15 +92,9 @@
 </author>
 <published>2025-07-18T15:53:01+00:00</published>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=01070d43248fb97f3b2a08d780ae5a392573ce34'/>
-<id>01070d43248fb97f3b2a08d780ae5a392573ce34</id>
+<id>urn:sha1:01070d43248fb97f3b2a08d780ae5a392573ce34</id>
 <content type='text'>
 </content>
-<content type='xhtml'>
-<div xmlns='http://www.w3.org/1999/xhtml'>
-<pre>
-</pre>
-</div>
-</content>
 </entry>
 <entry>
 <title>change overflow behavior in fltexpr; fix for readline event hook; fix for internal quoting of array subscripts in arithmetic expression contexts</title>
@@ -144,15 +105,9 @@
 </author>
 <published>2025-07-11T15:48:01+00:00</published>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=80a8f650a1defc3f72539c3b57bf6d228c33c116'/>
-<id>80a8f650a1defc3f72539c3b57bf6d228c33c116</id>
+<id>urn:sha1:80a8f650a1defc3f72539c3b57bf6d228c33c116</id>
 <content type='text'>
 </content>
-<content type='xhtml'>
-<div xmlns='http://www.w3.org/1999/xhtml'>
-<pre>
-</pre>
-</div>
-</content>
 </entry>
 <entry>
 <title>fix for crash when executing PROMPT_COMMAND; fix for readline crash when rl_save_prompt is not followed by rl_set_prompt; fix for bash C-xg key binding listing completions; fix for precision overflow issue in printf; fix for readline non-multibyte builds</title>
@@ -163,15 +118,9 @@
 </author>
 <published>2025-07-09T20:33:00+00:00</published>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=a23c863e755dd862cb9e723f7d85578346e450a5'/>
-<id>a23c863e755dd862cb9e723f7d85578346e450a5</id>
+<id>urn:sha1:a23c863e755dd862cb9e723f7d85578346e450a5</id>
 <content type='text'>
 </content>
-<content type='xhtml'>
-<div xmlns='http://www.w3.org/1999/xhtml'>
-<pre>
-</pre>
-</div>
-</content>
 </entry>
 <entry>
 <title>update formatted documentation; fix typo in bashline.c; update system-dependent tests</title>
@@ -182,14 +131,8 @@
 </author>
 <published>2025-07-08T13:59:39+00:00</published>
 <link rel='alternate' type='text/html' href='https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=12ea4bfec3e9f06fea2930a55f49c4c2ccf08071'/>
-<id>12ea4bfec3e9f06fea2930a55f49c4c2ccf08071</id>
+<id>urn:sha1:12ea4bfec3e9f06fea2930a55f49c4c2ccf08071</id>
 <content type='text'>
 </content>
-<content type='xhtml'>
-<div xmlns='http://www.w3.org/1999/xhtml'>
-<pre>
-</pre>
-</div>
-</content>
 </entry>
 </feed>
```